### PR TITLE
Clean up for Crystal 1.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Wordsmith
+name: Wordsmith CI
 
 on:
   push:
@@ -8,18 +8,36 @@ on:
 
 jobs:
   check_format:
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal_version:
+          - 0.35.1
+          - 0.36.1
+          - 1.0.0
+        experimental:
+          - false
+    continue-on-error: ${{ matrix.experimental }}
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:0.35.0
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     steps:
       - uses: actions/checkout@v1
       - name: Format
         run: crystal tool format --check
 
   specs:
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal_version:
+          - 0.35.1
+          - 0.36.1
+          - 1.0.0
+        experimental:
+          - false
+    continue-on-error: ${{ matrix.experimental }}
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:0.35.0
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     steps:
       - uses: actions/checkout@v2
       - name: Cache Crystal

--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,6 @@ authors:
   - Paul Smith <paulcsmith0218@gmail.com>
   - Flinn Mueller <theflinnster@gmail.com>
 
-crystal: 0.35.1
+crystal: ">= 0.35.1, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
Updating the crystal version constraint to allow for going through Crystal 1.0. Also updating the CI to include a matrix of the different supported crystal versions. 
