### PR TITLE
Add missing inline documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy docs
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   deploy:
@@ -16,7 +16,7 @@ jobs:
       - name: "Install shards"
         run: shards install
       - name: "Generate docs"
-        run: crystal docs
+        run: crystal docs --project-name=Wordsmith
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /doc/
+/docs/
 /lib/
 /bin/
 /.shards/

--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Wordsmith::Inflector.humanize("employee_id") # "Employee"
 Wordsmith::Inflector.titleize("amazon web services") # "Amazon Web Services"
 Wordsmith::Inflector.tableize("User") # "users"
 Wordsmith::Inflector.classify("users") # "User"
-Wordsmith::Inflector.dasherize("PostOffice") # "post-office"
+Wordsmith::Inflector.dasherize("post_office") # "post-office"
 Wordsmith::Inflector.ordinalize(4) # "4th"
+Wordsmith::Inflector.demodulize("Helpers::Mixins::User") # "User"
+Wordsmith::Inflector.deconstantize("User::FREE_TIER_COMMENTS") # "User"
+Wordsmith::Inflector.foreign_key("Person") # "person_id"
+Wordsmith::Inflector.parameterize("Admin/product") # "admin-product"
 ```
 
 ## Contributing

--- a/src/wordsmith.cr
+++ b/src/wordsmith.cr
@@ -1,6 +1,8 @@
 require "./wordsmith/**"
 require "./wordsmith/inflector/**"
 
+# Wordsmith is a library for pluralizing, ordinalizing, singularizing and doing other fun and useful things with words.
 module Wordsmith
-  VERSION = "0.2.2"
+  # The current Wordsmith version is defined in `shard.yml`
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end

--- a/src/wordsmith/inflector/inflections.cr
+++ b/src/wordsmith/inflector/inflections.cr
@@ -2,24 +2,33 @@ module Wordsmith
   module Inflector
     extend self
 
+    # Store the current set of stored inflection logic.
+    @@inflections = Inflections.new
+
+    # Return the current set of stored inflection logic.
+    def inflections
+      @@inflections
+    end
+
+    # Create and manipulate the set of valid Wordsmith inflections.
     class Inflections
+      # Create and manipulate the set of words that Wordsmith should leave as-is.
       class Uncountables
         forward_missing_to @uncoundtables_array
 
+        # Create a new object to store the collection of uncountable words and patterns.
         def initialize
           @regex_array = Array(Regex).new
           @uncoundtables_array = [] of String
         end
 
+        # Remove an entry from the set of uncountable words and patterns.
         def delete(entry)
           @uncoundtables_array.delete entry
           @regex_array.delete(to_regex(entry))
         end
 
-        def <<(*word)
-          add(word)
-        end
-
+        # Add an entry to the set of uncountable words and patterns.
         def add(words)
           words = words.to_a.flatten.map(&.downcase)
           concat(words)
@@ -27,17 +36,41 @@ module Wordsmith
           self
         end
 
+        # :ditto:
+        def <<(*word)
+          add(word)
+        end
+
+        # Check whether or not a provided string is currently considered uncountable.
         def uncountable?(str)
           @regex_array.any?(&.match(str))
         end
 
+        # Convert a provided string to a regular expression.
         private def to_regex(string)
           /\b#{::Regex.escape(string)}\Z/i
         end
       end
 
-      getter :plurals, :singulars, :uncountables, :humans, :acronyms, :acronym_regex
+      # Return the current set of matched pluralization patterns.
+      getter :plurals
 
+      # Return the current set of matched singularization patterns.
+      getter :singulars
+
+      # Return the current set of items considered uncountable.
+      getter :uncountables
+
+      # Return the current set of items that can be humanized.
+      getter :humans
+
+      # Return the current set of acronym strings to recognize.
+      getter :acronyms
+
+      # Return the current set of acronym `Regex` patterns to recognize.
+      getter :acronym_regex
+
+      # Create a new object to store the collection of inflectable words and patterns.
       def initialize
         @plurals = Hash(Regex, String).new
         @singulars = Hash(Regex, String).new
@@ -47,11 +80,34 @@ module Wordsmith
         @acronym_regex = /(?=a)b/
       end
 
+      # Define a new acronym that should be recognized.
+      #
+      # Example:
+      # ```
+      # Wordsmith::Inflector.inflections.acronym("API")
+      # Wordsmith::Inflector.camelize("API")   # => "API"
+      # Wordsmith::Inflector.underscore("API") # => "api"
+      # Wordsmith::Inflector.humanize("API")   # => "API"
+      # Wordsmith::Inflector.titleize("API")   # => "API"
+      # ```
       def acronym(word)
         @acronyms[word.downcase] = word
         @acronym_regex = /#{acronyms.values.join("|")}/
       end
 
+      # Define a new pluralization rule, either using a pattern or string.
+      #
+      # Example with a `Regex` pattern:
+      # ```
+      # Wordsmith::Inflector.inflections.plural(/^goose(\S*)$/i, "geese\\1")
+      # Wordsmith::Inflector.pluralize("goosebumps") # => "geesebumps"
+      # ```
+      #
+      # Example with a `String`:
+      # ```
+      # Wordsmith::Inflector.inflections.plural("goosebumps", "geesebumps")
+      # Wordsmith::Inflector.pluralize("goosebumps") # => "geesebumps"
+      # ```
       def plural(rule : String | Regex, replacement : String)
         if rule.is_a?(String)
           @uncountables.delete(rule)
@@ -62,6 +118,19 @@ module Wordsmith
         @plurals = new_plural.merge(@plurals)
       end
 
+      # Define a new singularization rule, either using a pattern or string.
+      #
+      # Example with a `Regex` pattern:
+      # ```
+      # Wordsmith::Inflector.inflections.singular(/^(ox)en$/i, "\\1")
+      # Wordsmith::Inflector.singularize("oxen") # => "ox"
+      # ```
+      #
+      # Example with a `String`:
+      # ```
+      # Wordsmith::Inflector.inflections.singular("mice", "mouse")
+      # Wordsmith::Inflector.singularize("mice") # => "mouse"
+      # ```
       def singular(rule : String | Regex, replacement : String)
         if rule.is_a?(String)
           @uncountables.delete(rule)
@@ -72,6 +141,14 @@ module Wordsmith
         @singulars = new_singular.merge(@singulars)
       end
 
+      # Define a new irregular `String` with a direct translation between singular and plural form.
+      #
+      # Example:
+      # ```
+      # Wordsmith::Inflector.inflections.irregular("person", "people")
+      # Wordsmith::Inflector.singularize("people") # => "person"
+      # Wordsmith::Inflector.pluralize("person")   # => "people"
+      # ```
       def irregular(singular : String, plural : String)
         @uncountables.delete(singular)
         @uncountables.delete(plural)
@@ -101,15 +178,51 @@ module Wordsmith
         end
       end
 
+      # Define a new uncountable `String` that should stay the same between singular and plural form.
+      #
+      # Example with a single `String`:
+      # ```
+      # Wordsmith::Inflector.inflections.uncountable("jedi")
+      # Wordsmith::Inflector.singularize("jedi") # => "jedi"
+      # Wordsmith::Inflector.pluralize("jedi")   # => "jedi"
+      # ```
+      #
+      # Example with a single `String`:
+      # ```
+      # Wordsmith::Inflector.inflections.uncountable(%w(fish jedi))
+      # Wordsmith::Inflector.singularize("jedi") # => "jedi"
+      # Wordsmith::Inflector.pluralize("fish")   # => "fish"
+      # ```
       def uncountable(*words)
         @uncountables.add(words.to_a)
       end
 
+      # Define a new humanize rule, either using a pattern or string.
+      #
+      # Example with a `Regex` pattern:
+      # ```
+      # Wordsmith::Inflector.inflections.human(/^prefix_/i, "\\1")
+      # Wordsmith::Inflector.humanize("prefix_request") # => "Request"
+      # ```
+      #
+      # Example with a `String`:
+      # ```
+      # Wordsmith::Inflector.inflections.human("col_rpted_bugs", "Reported bugs")
+      # Wordsmith::Inflector.humanize("col_rpted_bugs") # => "Reported bugs"
+      # ```
       def human(rule : String | Regex, replacement : String)
         rule = /#{rule}/ if rule.is_a?(String)
         @humans = {rule => replacement}.merge(@humans)
       end
 
+      # Remove all currently-stored Inflection rules, or a subset of rules.
+      #
+      # Subsets can be provided with the `scope` parameter, and can be any of:
+      # * `:all`
+      # * `:plurals`
+      # * `:singulars`
+      # * `:uncountables`
+      # * `:humans`
       def clear(scope = :all)
         scopes = scope == :all ? [:plurals, :singulars, :uncountables, :humans] : [scope]
 
@@ -126,12 +239,6 @@ module Wordsmith
           end
         end
       end
-    end
-
-    @@inflections = Inflections.new
-
-    def inflections
-      @@inflections
     end
   end
 end

--- a/src/wordsmith/inflector/methods.cr
+++ b/src/wordsmith/inflector/methods.cr
@@ -4,14 +4,39 @@ module Wordsmith
   module Inflector
     extend self
 
+    # Given a word, return the plural version of that word.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.pluralize("sandal") # => "sandals"
+    # Wordsmith::Inflector.pluralize("person") # => "people"
+    # Wordsmith::Inflector.pluralize("people") # => "people"
+    # ```
     def pluralize(word)
       apply_inflections(word, inflections.plurals)
     end
 
+    # Given a word, return the singular version of that word.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.singularize("sandals") # => "sandal"
+    # Wordsmith::Inflector.singularize("people")  # => "person"
+    # Wordsmith::Inflector.singularize("person")  # => "person"
+    # ```
     def singularize(word)
       apply_inflections(word, inflections.singulars)
     end
 
+    # Convert a given word to the camel-case version of that word.
+    #
+    # Optionally, a second parameter can be provided that controls whether or not the first letter is capitalized.
+    #
+    # Examples:
+    # ```
+    # Wordsmith::Inflector.camelize("application_controller")                                # => "ApplicationController"
+    # Wordsmith::Inflector.camelize("application_controller", uppercase_first_letter: false) # => "applicationController"
+    # ```
     def camelize(term, uppercase_first_letter = true)
       string = term.to_s
       string = if uppercase_first_letter
@@ -30,6 +55,12 @@ module Wordsmith
       string
     end
 
+    # Convert a given camel-case word to the underscored version of that word.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.underscore("ApplicationController") # => "application_controller"
+    # ```
     def underscore(camel_cased_word)
       return camel_cased_word unless camel_cased_word =~ /[A-Z-]|::/
       word = camel_cased_word.to_s.gsub("::", "/")
@@ -43,6 +74,16 @@ module Wordsmith
       word
     end
 
+    # Convert a given word to the human-friendly version of that word.
+    #
+    # Capitalization and whether or not to retain an `_id` suffix can be controlled with optional parameters.
+    #
+    # Examples:
+    # ```
+    # Wordsmith::Inflector.humanize("employee_id")                       # => "Employee"
+    # Wordsmith::Inflector.humanize("employee_id", capitalize: false)    # => "employee"
+    # Wordsmith::Inflector.humanize("employee_id", keep_id_suffix: true) # => "Employee id"
+    # ```
     def humanize(lower_case_and_underscored_word, capitalize = true, keep_id_suffix = false)
       result = lower_case_and_underscored_word.to_s.dup
 
@@ -70,29 +111,69 @@ module Wordsmith
       result
     end
 
+    # Capitalize the first letter of a given word.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.upcase_first("lucky") # => "Lucky"
+    # ```
     def upcase_first(string)
       string.size > 0 ? string[0].to_s.upcase + string[1..-1] : ""
     end
 
+    # Convert a given word to the titleized version of that word, which generally means each word is capitalized.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.titleize("amazon web services") # => "Amazon Web Services"
+    # ```
     def titleize(word, keep_id_suffix = false)
       humanize(underscore(word), keep_id_suffix: keep_id_suffix).gsub(/\b(?<!\w['’`])[a-z]/) do |match|
         match.capitalize
       end
     end
 
+    # Convert a given class name to the database table name for that class.
+    #
+    # Examples:
+    # ```
+    # Wordsmith::Inflector.tableize("User")   # => "users"
+    # Wordsmith::Inflector.tableize("Person") # => "people"
+    # ```
     def tableize(class_name)
       pluralize(underscore(class_name))
     end
 
+    # Convert a given table name to the class name for that table.
+    #
+    # Examples:
+    # ```
+    # Wordsmith::Inflector.classify("users")               # => "User"
+    # Wordsmith::Inflector.classify("people")              # => "Person"
+    # Wordsmith::Inflector.classify("schema.users")        # => "User"
+    # Wordsmith::Inflector.classify("schema.public.users") # => "User"
+    # ```
     def classify(table_name)
       # strip out any leading schema name
       camelize(singularize(table_name.to_s.sub(/.*\./, "")))
     end
 
+    # Convert a given underscore-separated word to the same word, separated by dashes.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.dasherize("post_office") # => "post-office"
+    # ```
     def dasherize(underscored_word)
       underscored_word.tr("_", "-")
     end
 
+    # Remove leading modules from a provided class name path.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.demodulize("Helpers::Mixins::User") # => "User"
+    # ```
     def demodulize(path)
       path = path.to_s
       if i = path.rindex("::")
@@ -102,14 +183,35 @@ module Wordsmith
       end
     end
 
+    # Remove any trailing constants from the provided path.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.deconstantize("Helpers::Mixins::User::FREE_TIER_COMMENTS") # => "Helpers::Mixins::User"
+    # ```
     def deconstantize(path)
       path.to_s[0, path.rindex("::") || 0] # implementation based on the one in facets' Module#spacename
     end
 
+    # Determine the foreign key representation of a given class name.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.foreign_key("Person") # => "person_id"
+    # ```
     def foreign_key(class_name, separate_class_name_and_id_with_underscore = true)
       underscore(demodulize(class_name)) + (separate_class_name_and_id_with_underscore ? "_id" : "id")
     end
 
+    # Determine the ordinal suffix for a given number.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.ordinal(1) # => "st"
+    # Wordsmith::Inflector.ordinal(2) # => "nd"
+    # Wordsmith::Inflector.ordinal(3) # => "rd"
+    # Wordsmith::Inflector.ordinal(4) # => "th"
+    # ```
     def ordinal(number)
       abs_number = number.to_i.abs
 
@@ -125,10 +227,29 @@ module Wordsmith
       end
     end
 
+    # Given a number, return the number with the correct ordinal suffix.
+    #
+    # Example:
+    # ```
+    # Wordsmith::Inflector.ordinalize(1) # => "1st"
+    # Wordsmith::Inflector.ordinalize(2) # => "2nd"
+    # Wordsmith::Inflector.ordinalize(3) # => "3rd"
+    # Wordsmith::Inflector.ordinalize(4) # => "4th"
+    # ```
     def ordinalize(number)
       "#{number}#{ordinal(number)}"
     end
 
+    # Convert the given string to a parameter-friendly version.
+    #
+    # The used separator and whether or not to preserve the original object case can be controlled through optional parameters.
+    #
+    # Examples:
+    # ```
+    # Wordsmith::Inflector.parameterize("Admin/product")                       # => "admin-product"
+    # Wordsmith::Inflector.parameterize("Admin::Product", separator: "_")      # => "admin_product"
+    # Wordsmith::Inflector.parameterize("Admin::Product", preserve_case: true) # => "Admin-Product"
+    # ```
     def parameterize(content : String, separator : String? = "-", preserve_case : Bool = false)
       parameterized_string = content.gsub(/[^a-z0-9\-_]+/i, separator)
 
@@ -149,6 +270,7 @@ module Wordsmith
       parameterized_string
     end
 
+    # Apply the previously-defined inflection rules to a given word.
     private def apply_inflections(word, rules)
       result = word.to_s.dup
 


### PR DESCRIPTION
Closes #7 

I also:
- Converted the `VERSION` constant to a macro so we can just update `shard.yml`
- Updated the README to include a few missing methods
- Updated the `project_name` parameter in the documentation generation to `Wordsmith` from the default `wordsmith`