### PR TITLE
Add ws command line interface.

### DIFF
--- a/.github/workflows/alpine_x86_64_release.yml
+++ b/.github/workflows/alpine_x86_64_release.yml
@@ -25,16 +25,15 @@ jobs:
         run: crystal spec --order=random --error-on-warnings
       - name: package information
         run: |
-          echo "PKG_NAME=ws" >> $GITHUB_ENV
+          echo "BINARY_NAME=ws" >> $GITHUB_ENV
           echo "PKG_ARCH=x86_64" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: release binary
         id: release
         run: |
           shards build --production --release --progress --static --no-debug --link-flags="-s -Wl,-z,relro,-z,now"
-          strip ./bin/${PKG_NAME}
-          ASSERT_NAME=${PKG_NAME}-${RELEASE_VERSION}-${PKG_ARCH}-unknown-linux-musl.tar.gz
-          tar zcf ${ASSERT_NAME} bin/${DPKG_NAME} LICENSE
+          ASSERT_NAME=${BINARY_NAME}-${RELEASE_VERSION}-${PKG_ARCH}-unknown-linux-musl.tar.gz
+          tar zcf ${ASSERT_NAME} bin/${BINARY_NAME} LICENSE
           echo ::set-output name=ASSERT_NAME::${ASSERT_NAME}
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/alpine_x86_64_release.yml
+++ b/.github/workflows/alpine_x86_64_release.yml
@@ -25,7 +25,7 @@ jobs:
         run: crystal spec --order=random --error-on-warnings
       - name: package information
         run: |
-          echo "PKG_NAME=$(sed -n 's/^name: \(.*\)/\1/p' shard.yml |head -n1)" >> $GITHUB_ENV
+          echo "PKG_NAME=ws" >> $GITHUB_ENV
           echo "PKG_ARCH=x86_64" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: release binary

--- a/.github/workflows/alpine_x86_64_release.yml
+++ b/.github/workflows/alpine_x86_64_release.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:latest-alpine
+    steps:
+      - name: Cache shards
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/shards
+          key: ${{ runner.os }}-shards-${{ hashFiles('shard.yml') }}
+          restore-keys: ${{ runner.os }}-shards-
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Install shards
+        run: shards check || shards install
+      - name: Check formatting
+        run: crystal tool format --check
+      - name: Run tests
+        run: crystal spec --order=random --error-on-warnings
+      - name: package information
+        run: |
+          echo "PKG_NAME=$(sed -n 's/^name: \(.*\)/\1/p' shard.yml |head -n1)" >> $GITHUB_ENV
+          echo "PKG_ARCH=x86_64" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: release binary
+        id: release
+        run: |
+          shards build --production --release --progress --static --no-debug --link-flags="-s -Wl,-z,relro,-z,now"
+          strip ./bin/${PKG_NAME}
+          ASSERT_NAME=${PKG_NAME}-${RELEASE_VERSION}-${PKG_ARCH}-unknown-linux-musl.tar.gz
+          tar zcf ${ASSERT_NAME} bin/${DPKG_NAME} LICENSE
+          echo ::set-output name=ASSERT_NAME::${ASSERT_NAME}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ steps.release.outputs.ASSERT_NAME }}

--- a/.github/workflows/apple_darwin_release.yml
+++ b/.github/workflows/apple_darwin_release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check formatting
         run: crystal tool format --check
       - name: Run tests
-        run: KEMAL_ENV=test crystal spec --order=random --error-on-warnings
+        run: crystal spec --order=random --error-on-warnings
       - name: package information
         run: |
           echo "BINARY_NAME=ws" >> $GITHUB_ENV

--- a/.github/workflows/apple_darwin_release.yml
+++ b/.github/workflows/apple_darwin_release.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Cache shards
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/shards
+          key: ${{ runner.os }}-shards-${{ hashFiles('shard.yml') }}
+          restore-keys: ${{ runner.os }}-shards-
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Install shards
+        run: shards check || shards install
+      - name: Check formatting
+        run: crystal tool format --check
+      - name: Run tests
+        run: KEMAL_ENV=test crystal spec --order=random --error-on-warnings
+      - name: package information
+        run: |
+          echo "BINARY_NAME=ws" >> $GITHUB_ENV
+          echo "PKG_ARCH=x86_64" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: release binary
+        id: release
+        run: |
+          shards build --production --release --progress --no-debug
+          ASSERT_NAME=${BINARY_NAME}-${RELEASE_VERSION}-${PKG_ARCH}-apple-darwin.tar.gz
+          tar zcf ${ASSERT_NAME} bin/${BINARY_NAME} LICENSE
+          echo ::set-output name=ASSERT_NAME::${ASSERT_NAME}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ steps.release.outputs.ASSERT_NAME }}

--- a/.github/workflows/gnu_x86_64_release.yml
+++ b/.github/workflows/gnu_x86_64_release.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache shards
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/shards
+          key: ${{ runner.os }}-shards-${{ hashFiles('shard.yml') }}
+          restore-keys: ${{ runner.os }}-shards-
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Install shards
+        run: shards check || shards install
+      - name: Check formatting
+        run: crystal tool format --check
+      - name: Run tests
+        run: crystal spec --order=random --error-on-warnings
+      - name: package information
+        run: |
+          echo "BINARY_NAME=ws" >> $GITHUB_ENV
+          echo "PKG_ARCH=x86_64" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: release binary
+        id: release
+        run: |
+          shards build --production --release --progress --static --no-debug --link-flags="-s -Wl,-z,relro,-z,now"
+          ASSERT_NAME=${BINARY_NAME}-${RELEASE_VERSION}-${PKG_ARCH}-unknown-linux-gnu.tar.gz
+          tar zcf ${ASSERT_NAME} bin/${BINARY_NAME} LICENSE
+          echo ::set-output name=ASSERT_NAME::${ASSERT_NAME}
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ steps.release.outputs.ASSERT_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /lib/
 /bin/
 /.shards/
-
+/ws
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them
 /shard.lock

--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ Wordsmith::Inflector.parameterize("Admin/product") # "admin-product"
 Wordsmith comes with a `ws` CLI utility which allows you to process words from the command line. You can download it directly from the [releases page](https://github.com/luckyframework/wordsmith/releases).
 
 ```sh
+ ╰─ $ ./ws 
 Usage: ws <option> WORD
 
 Wordsmith is a library for pluralizing, singularizing and doing
 other fun and useful things with words.
 
 Command `ws` is the command line version of Wordsmith, not all
-features of Wordsmith are implemented.
+features of Wordsmith are implemented, for precompiled binary,
+please download from github releases page.
+
+https://github.com/luckyframework/wordsmith/releases
 
 some examples:
 
@@ -54,9 +58,9 @@ $: ws -p person # => people
 
 You can use it with pipe:
 
-$: echo "WordSmith" |ws -u # => word_smith
+$: echo "WordSmith" |ws -u |ws -d # => word-smith
 
-more examples, check https://github.com/luckyframework/wordsmith#usage
+more examples, please check https://github.com/luckyframework/wordsmith#usage
 
     -s WORD, --singularize=WORD      Return the singular version of the word.
     -p WORD, --pluralize=WORD        Return the plural version of the word.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Wordsmith::Inflector.foreign_key("Person") # "person_id"
 Wordsmith::Inflector.parameterize("Admin/product") # "admin-product"
 ```
 
-Wordsmith along with a `ws `command for works on command line, you can download it directly from [releases page](https://github.com/luckyframework/wordsmith/releases).
+Wordsmith comes with a `ws` CLI utility which allows you to process words from the command line. You can download it directly from the [releases page](https://github.com/luckyframework/wordsmith/releases).
 
 ```sh
 Usage: ws <option> WORD

--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ Wordsmith::Inflector.foreign_key("Person") # "person_id"
 Wordsmith::Inflector.parameterize("Admin/product") # "admin-product"
 ```
 
+Wordsmith along with a `ws `command for works on command line, you can download it directly from [releases page](https://github.com/luckyframework/wordsmith/releases).
+
+```sh
+Usage: ws <option> WORD
+
+Wordsmith is a library for pluralizing, singularizing and doing
+other fun and useful things with words.
+
+Command `ws` is the command line version of Wordsmith, not all
+feature of Wordsmith is implemented.
+
+some examples:
+
+$: ws -s people # => person
+$: ws -p person # => people
+
+You can use it with pipe:
+
+$: echo "WordSmith" |ws -u # => word_smith
+
+more examples, check https://github.com/luckyframework/wordsmith#usage
+
+    -s WORD, --singularize=WORD      Return the singular version of the word.
+    -p WORD, --pluralize=WORD        Return the plural version of the word.
+    -c WORD, --camelize=WORD         Return the camel-case version of that word.
+    -C WORD, --camelize-downcase=WORD
+                                     Return the camel-case version of that word, but the first letter not capitalized.
+    -u WORD, --underscore=WORD       Convert a given camel-case word to it's underscored version.
+    -d WORD, --dasherize=WORD        Convert a given underscore-separated word to the same word, separated by dashes.
+    -h, --help                       Show this help
+```
+
 ## Custom inflections
 
 If something isn't pluralizing correctly, it's easy to customize.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Wordsmith is a library for pluralizing, singularizing and doing
 other fun and useful things with words.
 
 Command `ws` is the command line version of Wordsmith, not all
-feature of Wordsmith is implemented.
+features of Wordsmith are implemented.
 
 some examples:
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,10 @@
 name: wordsmith
-version: 0.3.0
+version: 0.3.2
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
   - Flinn Mueller <theflinnster@gmail.com>
+  - Billy.Zheng <vil963@gmail.com>
 
 targets:
   ws:

--- a/shard.yml
+++ b/shard.yml
@@ -5,6 +5,10 @@ authors:
   - Paul Smith <paulcsmith0218@gmail.com>
   - Flinn Mueller <theflinnster@gmail.com>
 
+targets:
+  ws:
+    main: src/ws.cr
+
 crystal: ">= 1.4.0"
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,9 @@
 name: wordsmith
-version: 0.3.2
+version: 0.3.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
   - Flinn Mueller <theflinnster@gmail.com>
-  - Billy.Zheng <vil963@gmail.com>
 
 targets:
   ws:

--- a/src/wordsmith.cr
+++ b/src/wordsmith.cr
@@ -1,5 +1,4 @@
 require "./wordsmith/**"
-require "./wordsmith/inflector/**"
 
 # Wordsmith is a library for pluralizing, ordinalizing, singularizing and doing other fun and useful things with words.
 module Wordsmith

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -25,6 +25,10 @@ some examples:
 $: #{"ws -s people".colorize(:light_yellow)} # => person
 $: #{"ws -p person".colorize(:light_yellow)} # => people
 
+You can use it with pipe:
+
+$: #{"echo \"WordSmith\" |ws -u".colorize(:light_yellow)} # => word_smith
+
 more examples, check https://github.com/luckyframework/wordsmith#usage
 
 USAGE

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -16,7 +16,10 @@ Wordsmith is a library for pluralizing, singularizing and doing
 other fun and useful things with words.
 
 Command `ws` is the command line version of Wordsmith, not all
-features of Wordsmith are implemented.
+features of Wordsmith are implemented, for precompiled binary,
+please download from github releases page.
+
+https://github.com/luckyframework/wordsmith/releases
 
 some examples:
 
@@ -25,9 +28,9 @@ $: #{"ws -p person".colorize(:light_yellow)} # => people
 
 You can use it with pipe:
 
-$: #{"echo \"WordSmith\" |ws -u".colorize(:light_yellow)} # => word_smith
+$: #{"echo \"WordSmith\" |ws -u |ws -d".colorize(:light_yellow)} # => word-smith
 
-more examples, check https://github.com/luckyframework/wordsmith#usage
+more examples, please check https://github.com/luckyframework/wordsmith#usage
 
 USAGE
 

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -16,7 +16,7 @@ Wordsmith is a library for pluralizing, singularizing and doing
 other fun and useful things with words.
 
 Command `ws` is the command line version of Wordsmith, not all
-feature of Wordsmith is implemented.
+features of Wordsmith are implemented.
 
 some examples:
 

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -2,9 +2,7 @@ require "option_parser"
 require "colorize"
 require "./wordsmith"
 
-is_pipe = `test -p /proc/$$/fd/0; echo $?`.chomp == "0"
-
-if is_pipe
+if STDIN.info.type.pipe?
   ARGV << STDIN.gets.not_nil!
 else
   ARGV << "--help" if ARGV.empty?

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -1,0 +1,95 @@
+require "option_parser"
+require "colorize"
+require "./wordsmith"
+
+is_pipe = `test -p /proc/$$/fd/0; echo $?`.chomp == "0"
+
+if is_pipe
+  ARGV << STDIN.gets.not_nil!
+else
+  ARGV << "--help" if ARGV.empty?
+end
+
+OptionParser.parse do |parser|
+  parser.banner = <<-USAGE
+Usage: ws <option> WORD
+
+Wordsmith is a library for pluralizing, singularizing and doing
+other fun and useful things with words.
+
+Command `ws` is the command line version of Wordsmith, not all
+feature of Wordsmith is implemented.
+
+some examples:
+
+$: #{"ws -s people".colorize(:light_yellow)} # => person
+$: #{"ws -p person".colorize(:light_yellow)} # => people
+
+more examples, check https://github.com/luckyframework/wordsmith#usage
+
+USAGE
+
+  parser.missing_option do |flag|
+    STDERR.puts parser
+    exit 0
+  end
+
+  parser.on(
+    "-s WORD",
+    "--singularize=WORD",
+    "Return the singular version of the word."
+  ) do |word|
+    puts Wordsmith::Inflector.singularize(word)
+  end
+
+  parser.on(
+    "-p WORD",
+    "--pluralize=WORD",
+    "Return the plural version of the word."
+  ) do |word|
+    puts Wordsmith::Inflector.pluralize(word)
+  end
+
+  parser.on(
+    "-c WORD",
+    "--camelize=WORD",
+    "Return the camel-case version of that word."
+  ) do |word|
+    puts Wordsmith::Inflector.camelize(word)
+  end
+
+  parser.on(
+    "-C WORD",
+    "--camelize-downcase=WORD",
+    "Return the camel-case version of that word, but the first letter not capitalized."
+  ) do |word|
+    puts Wordsmith::Inflector.camelize(word)
+  end
+
+  parser.on(
+    "-u WORD",
+    "--underscore=WORD",
+    "Convert a given camel-case word to it's underscored version."
+  ) do |word|
+    puts Wordsmith::Inflector.underscore(word)
+  end
+
+  parser.on(
+    "-d WORD",
+    "--dasherize=WORD",
+    "Convert a given underscore-separated word to the same word, separated by dashes."
+  ) do |word|
+    puts Wordsmith::Inflector.dasherize(word)
+  end
+
+  parser.on("-h", "--help", "Show this help") do
+    puts parser
+    exit
+  end
+
+  parser.invalid_option do |flag|
+    STDERR.puts "ERROR: #{flag} is not a valid option.\n\n"
+    STDERR.puts parser
+    exit 1
+  end
+end

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -29,11 +29,6 @@ more examples, check https://github.com/luckyframework/wordsmith#usage
 
 USAGE
 
-  parser.missing_option do |flag|
-    STDERR.puts parser
-    exit 0
-  end
-
   parser.on(
     "-s WORD",
     "--singularize=WORD",


### PR DESCRIPTION
This commit including following changes:

1.  Add `src/ws.cr`, it used to build  `ws` command, it not required by default.
2. Add a new github action, when we are release a new version use git tag, it will built a packed version alpine static binary which can be download directly on release page, we probably should support download macOS version, but i need investigate how to do it, because i never use Mac.
3. some Improvement.

Code probably still optimizing, but it works!