### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         crystal_version:
           - 1.4.0
+          - 1.5.0
           - latest
         experimental:
           - false

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: wordsmith
-version: 0.3.0
+version: 0.4.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/src/ws.cr
+++ b/src/ws.cr
@@ -87,6 +87,11 @@ USAGE
     exit
   end
 
+  parser.on("-v", "--version", "Show Wordsmith version") do
+    puts Wordsmith::VERSION
+    exit
+  end
+
   parser.invalid_option do |flag|
     STDERR.puts "ERROR: #{flag} is not a valid option.\n\n"
     STDERR.puts parser


### PR DESCRIPTION
This release includes a new `ws` binary that can be downloaded to use Wordsmith from the CLI.