### PR TITLE
adding IO method overloads.

### DIFF
--- a/spec/inflector_spec.cr
+++ b/spec/inflector_spec.cr
@@ -24,6 +24,12 @@ describe Wordsmith::Inflector do
       Wordsmith::Inflector.pluralize("").should eq ""
     end
 
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.pluralize(io, "thing")
+      io.to_s.should eq("things")
+    end
+
     SingularToPlural.each do |_singular, plural|
       it "should pluralize #{plural}" do
         Wordsmith::Inflector.pluralize(plural).should eq plural
@@ -57,6 +63,12 @@ describe Wordsmith::Inflector do
       Wordsmith::Inflector.inflections.singular("persons", "person")
       Wordsmith::Inflector.singularize("persons").should eq("person")
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.singularize(io, "things")
+      io.to_s.should eq("thing")
+    end
   end
 
   describe "camelize" do
@@ -77,6 +89,12 @@ describe Wordsmith::Inflector do
 
     it "test camelize with underscores" do
       Wordsmith::Inflector.camelize("Camel_Case").should eq "CamelCase"
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.camelize(io, "Camel_Case")
+      io.to_s.should eq "CamelCase"
     end
   end
 
@@ -104,6 +122,12 @@ describe Wordsmith::Inflector do
         Wordsmith::Inflector.underscore(camel).should eq underscore
       end
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.underscore(io, "CamelCase")
+      io.to_s.should eq "camel_case"
+    end
   end
 
   describe "humanize" do
@@ -124,6 +148,12 @@ describe Wordsmith::Inflector do
         Wordsmith::Inflector.humanize(underscore, keep_id_suffix: true).should eq human
       end
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.humanize(io, "employee_salary")
+      io.to_s.should eq "Employee salary"
+    end
   end
 
   describe "upcase_first" do
@@ -137,6 +167,12 @@ describe Wordsmith::Inflector do
       tests.each do |from, to|
         Wordsmith::Inflector.upcase_first(from).should eq to
       end
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.upcase_first(io, "hello world")
+      io.to_s.should eq "Hello world"
     end
   end
 
@@ -152,6 +188,12 @@ describe Wordsmith::Inflector do
         Wordsmith::Inflector.titleize(before, keep_id_suffix: true).should eq titleized
       end
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.titleize(io, "active_record")
+      io.to_s.should eq "Active Record"
+    end
   end
 
   describe "tableize" do
@@ -159,6 +201,12 @@ describe Wordsmith::Inflector do
       it "should tableize #{class_name}" do
         Wordsmith::Inflector.tableize(class_name).should eq table_name
       end
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.tableize(io, "PrimarySpokesman")
+      io.to_s.should eq "primary_spokesmen"
     end
   end
 
@@ -177,6 +225,12 @@ describe Wordsmith::Inflector do
     it "should classify with leading schema name" do
       Wordsmith::Inflector.classify("schema.foo_bar").should eq "FooBar"
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.classify(io, :foo_bars)
+      io.to_s.should eq "FooBar"
+    end
   end
 
   describe "dasherize" do
@@ -190,6 +244,12 @@ describe Wordsmith::Inflector do
       it "should underscore as reverse of dasherize #{underscored}" do
         Wordsmith::Inflector.underscore(Wordsmith::Inflector.dasherize(underscored)).should eq underscored
       end
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.dasherize(io, "street_address")
+      io.to_s.should eq "street-address"
     end
   end
 
@@ -205,6 +265,12 @@ describe Wordsmith::Inflector do
       it "should demodulize #{from}" do
         Wordsmith::Inflector.demodulize(from).should eq to
       end
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.demodulize(io, "MyApplication::Billing::Account")
+      io.to_s.should eq "Account"
     end
   end
 
@@ -224,6 +290,12 @@ describe Wordsmith::Inflector do
         Wordsmith::Inflector.deconstantize(from).should eq to
       end
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.deconstantize(io, "MyApplication::Billing::Account")
+      io.to_s.should eq "MyApplication::Billing"
+    end
   end
 
   describe "foreign_key" do
@@ -238,6 +310,12 @@ describe Wordsmith::Inflector do
         Wordsmith::Inflector.foreign_key(klass, false).should eq foreign_key
       end
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.foreign_key(io, "Person")
+      io.to_s.should eq "person_id"
+    end
   end
 
   describe "ordinal" do
@@ -246,6 +324,12 @@ describe Wordsmith::Inflector do
         (number + Wordsmith::Inflector.ordinal(number)).should eq ordinalized
       end
     end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.ordinal(io, 4)
+      io.to_s.should eq "th"
+    end
   end
 
   describe "ordinalize" do
@@ -253,6 +337,12 @@ describe Wordsmith::Inflector do
       it "should ordinalize #{number}" do
         Wordsmith::Inflector.ordinalize(number).should eq ordinalized
       end
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.ordinalize(io, 4)
+      io.to_s.should eq "4th"
     end
   end
 
@@ -268,6 +358,12 @@ describe Wordsmith::Inflector do
         Wordsmith::Inflector.parameterize(before, "_", true).should eq parameterized
         Wordsmith::Inflector.parameterize(before, "_").should eq parameterized.downcase
       end
+    end
+
+    it "takes an IO overload" do
+      io = IO::Memory.new
+      Wordsmith::Inflector.parameterize(io, "Admin::Product")
+      io.to_s.should eq "admin-product"
     end
   end
 

--- a/src/wordsmith/inflector/methods.cr
+++ b/src/wordsmith/inflector/methods.cr
@@ -16,6 +16,18 @@ module Wordsmith
       apply_inflections(word, inflections.plurals)
     end
 
+    # Given an IO and a word, it appends the plural version of that word
+    # to the IO.
+    #
+    # Example:
+    # ```
+    # io = IO::Memory.new
+    # Wordsmith::Inflector.pluralize(io, "person")
+    # io.to_s # => "people"
+    def pluralize(io : IO, word : String) : Nil
+      apply_inflections(io, word, inflections.plurals)
+    end
+
     # Given a word, return the singular version of that word.
     #
     # Example:
@@ -26,6 +38,18 @@ module Wordsmith
     # ```
     def singularize(word : String) : String
       apply_inflections(word, inflections.singulars)
+    end
+
+    # Given an IO and a word, it appends the singular version of that word
+    # to the IO.
+    #
+    # Example:
+    # ```
+    # io = IO::Memory.new
+    # Wordsmith::Inflector.singularize(io, "people")
+    # io.to_s # => "person"
+    def singularize(io : IO, word : String) : Nil
+      apply_inflections(io, word, inflections.singulars)
     end
 
     # Convert a given word to the camel-case version of that word.
@@ -54,6 +78,11 @@ module Wordsmith
       string
     end
 
+    # :ditto:
+    def camelize(io : IO, term : String, uppercase_first_letter : Bool = true) : Nil
+      io << camelize(term, uppercase_first_letter)
+    end
+
     # Convert a given camel-case word to the underscored version of that word.
     #
     # Example:
@@ -71,6 +100,11 @@ module Wordsmith
       word = word.tr("-", "_")
       word = word.downcase
       word
+    end
+
+    # :ditto:
+    def underscore(io : IO, camel_cased_word : String) : Nil
+      io << underscore(camel_cased_word)
     end
 
     # Convert a given word to the human-friendly version of that word.
@@ -110,6 +144,11 @@ module Wordsmith
       result
     end
 
+    # :ditto:
+    def humanize(io : IO, lower_case_and_underscored_word : String, capitalize : Bool = true, keep_id_suffix : Bool = false) : Nil
+      io << humanize(lower_case_and_underscored_word, capitalize, keep_id_suffix)
+    end
+
     # Capitalize the first letter of a given word.
     #
     # Example:
@@ -118,6 +157,11 @@ module Wordsmith
     # ```
     def upcase_first(string : String) : String
       string.size > 0 ? string[0].upcase + string[1..-1] : ""
+    end
+
+    # :ditto:
+    def upcase_first(io : IO, string : String) : Nil
+      io << upcase_first(string)
     end
 
     # Convert a given word to the titleized version of that word, which generally means each word is capitalized.
@@ -132,6 +176,11 @@ module Wordsmith
       end
     end
 
+    # :ditto:
+    def titleize(io : IO, word : String, keep_id_suffix : Bool = false) : Nil
+      io << titleize(word, keep_id_suffix)
+    end
+
     # Convert a given class name to the database table name for that class.
     #
     # Examples:
@@ -141,6 +190,11 @@ module Wordsmith
     # ```
     def tableize(class_name : String) : String
       pluralize(underscore(class_name))
+    end
+
+    # :ditto:
+    def tableize(io : IO, class_name : String) : Nil
+      io << tableize(class_name)
     end
 
     # Convert a given table name to the class name for that table.
@@ -157,6 +211,11 @@ module Wordsmith
       camelize(singularize(table_name.to_s.sub(/.*\./, "")))
     end
 
+    # :ditto:
+    def classify(io : IO, table_name : String | Symbol) : Nil
+      io << classify(table_name)
+    end
+
     # Convert a given underscore-separated word to the same word, separated by dashes.
     #
     # Example:
@@ -165,6 +224,11 @@ module Wordsmith
     # ```
     def dasherize(underscored_word : String) : String
       underscored_word.tr("_", "-")
+    end
+
+    # :ditto:
+    def dasherize(io : IO, underscored_word : String) : Nil
+      io << dasherize(underscored_word)
     end
 
     # Remove leading modules from a provided class name path.
@@ -181,6 +245,11 @@ module Wordsmith
       end
     end
 
+    # :ditto:
+    def demodulize(io : IO, path : String) : Nil
+      io << demodulize(path)
+    end
+
     # Remove any trailing constants from the provided path.
     #
     # Example:
@@ -191,6 +260,11 @@ module Wordsmith
       path[0, path.rindex("::") || 0] # implementation based on the one in facets' Module#spacename
     end
 
+    # :ditto:
+    def deconstantize(io : IO, path : String) : Nil
+      io << deconstantize(path)
+    end
+
     # Determine the foreign key representation of a given class name.
     #
     # Example:
@@ -199,6 +273,11 @@ module Wordsmith
     # ```
     def foreign_key(class_name : String, separate_class_name_and_id_with_underscore : Bool = true) : String
       underscore(demodulize(class_name)) + (separate_class_name_and_id_with_underscore ? "_id" : "id")
+    end
+
+    # :ditto:
+    def foreign_key(io : IO, class_name : String, separate_class_name_and_id_with_underscore : Bool = true) : Nil
+      io << foreign_key(class_name, separate_class_name_and_id_with_underscore)
     end
 
     # Determine the ordinal suffix for a given number.
@@ -226,6 +305,11 @@ module Wordsmith
       end
     end
 
+    # :ditto:
+    def ordinal(io : IO, number : Int | String) : Nil
+      io << ordinal(number)
+    end
+
     # Given a number, return the number with the correct ordinal suffix.
     #
     # Example:
@@ -238,6 +322,11 @@ module Wordsmith
     # TODO: This should only take an Int
     def ordinalize(number : Int | String) : String
       "#{number}#{ordinal(number)}"
+    end
+
+    # :ditto:
+    def ordinalize(io : IO, number : Int | String) : Nil
+      io << ordinalize(number)
     end
 
     # Convert the given string to a parameter-friendly version.
@@ -270,6 +359,11 @@ module Wordsmith
       parameterized_string
     end
 
+    # :ditto:
+    def parameterize(io : IO, content : String, separator : String? = "-", preserve_case : Bool = false) : Nil
+      io << parameterize(content, separator, preserve_case)
+    end
+
     # Apply the previously-defined inflection rules to a given word.
     private def apply_inflections(word : String, rules : Enumerable) : String
       result = word.dup
@@ -285,6 +379,10 @@ module Wordsmith
         }
         result
       end
+    end
+
+    private def apply_inflections(io : IO, word : String, rules : Enumerable) : Nil
+      io << apply_inflections(word, rules)
     end
   end
 end


### PR DESCRIPTION
Fixes #27

This PR only adds the method overloads that take an `IO`. This is more of just syntactic sugar shortcut as opposed to any real performance benefit. For example, if you look at `classify`, this could easily take a refactor to fully utilize the `io`. I think those can come later in #30. This at least allows you to start using the IO method overloads and then take advantage of performance refactors later without having to change your code again. 